### PR TITLE
Add ArduinoGraphics as a library dependency

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/arduino-libraries/Modulino
 architectures=*
 includes=Modulino.h
-depends=STM32duino VL53L4CD,STM32duino VL53L4ED,Arduino_LSM6DSOX,Arduino_LPS22HB,Arduino_HS300x
+depends=STM32duino VL53L4CD,STM32duino VL53L4ED,Arduino_LSM6DSOX,Arduino_LPS22HB,Arduino_HS300x,ArduinoGraphics


### PR DESCRIPTION
The ArduinoGraphics library are used by these examples:

* [examples/Modulino_Thermo/TemperatureHumidityMatrix/TemperatureHumidityMatrix.ino](https://github.com/arduino-libraries/Modulino/blob/485e3d294d4c5a6b094f5b3b3c9e0cc1d222136d/examples/Modulino_Thermo/TemperatureHumidityMatrix/TemperatureHumidityMatrix.ino)
* [examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino](https://github.com/arduino-libraries/Modulino/blob/485e3d294d4c5a6b094f5b3b3c9e0cc1d222136d/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino)

Compilation will fail for these examples unless the user has manually installed the ArduinoGraphics library.

Example of compilation error:

```
/private/var/folders/58/gntldnl9249ck9fjblgv9jdw0000gp/T/.arduinoIDE-unsaved2024104-2234-z4s2yo.tblw/FirmwareUpdater/FirmwareUpdater.ino:1:10: fatal error: ArduinoGraphics.h: No such file or directory
 #include "ArduinoGraphics.h"
          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
exit status 1

Compilation error: ArduinoGraphics.h: No such file or directory
```

This problem can be avoided by declaring ArduinoGraphics as a library dependency in `library.properties`.