### PR TITLE
Add #include guard around Modulino.h

### DIFF
--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -1,3 +1,6 @@
+#ifndef ARDUINO_LIBRARIES_MODULINO_H
+#define ARDUINO_LIBRARIES_MODULINO_H
+
 // Copyright (c) 2024 Arduino SA
 // SPDX-License-Identifier: MPL-2.0
 
@@ -506,3 +509,5 @@ private:
   float internal = NAN;
   _distance_api* api = nullptr;
 };
+
+#endif


### PR DESCRIPTION
My project currently cannot include modulino.h from two source files. An include guard could resolve this issue.