### PR TITLE
Portenta Mid Carrier Proto shield, firmware updater fix

### DIFF
--- a/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino
+++ b/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino
@@ -1,5 +1,7 @@
+#if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4) 
 #include "ArduinoGraphics.h"
 #include "Arduino_LED_Matrix.h"
+#endif
 
 #include "Modulino.h"
 #include "Wire.h"
@@ -20,11 +22,14 @@ void setup() {
   }
 
   auto result = flash(node_base_bin, node_base_bin_len);
+  
+  #if defined(ARDUINO_MINIMA) || defined(ARDUINO_UNOWIFIR4)
   if (result) {
     matrixInitAndDraw("PASS");
   } else {
     matrixInitAndDraw("FAIL");
   }
+  #endif
 }
 
 void loop() {
@@ -53,6 +58,7 @@ class SerialVerbose {
     bool _verbose;
 };
 
+#if defined(ARDUINO_MINIMA) ||defined(ARDUINO_UNOWIFIR4)
 ArduinoLEDMatrix matrix;
 
 void matrixInitAndDraw(char* text) {
@@ -67,6 +73,7 @@ void matrixInitAndDraw(char* text) {
 
   matrix.endDraw();
 }
+#endif
 
 bool flash(const uint8_t* binary, size_t lenght, bool verbose) {
 


### PR DESCRIPTION
Modified the FirmwareUpdater sketch to not compile anything related to the Arduino_LED_Matrix library when the Arduino UNO R4 is NOT the target board.

The case scenario is when the Portenta Mid Carrier Proto shield is being used.