### PR TITLE
add `available()` function for Modulino Movement

### DIFF
--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -317,6 +317,12 @@ public:
     }
     return 0;
   }
+  int available() {
+    if (initialized) {
+      return _imu->accelerationAvailable();
+    }
+    return 0;
+  }
   float getX() {
     return x;
   }


### PR DESCRIPTION
`available()`: query if new acceleration data from the modulino is available