### PR TITLE
added support for deadzone on joystick due to rest position drift

### DIFF
--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -166,10 +166,13 @@ public:
   bool update() {
     uint8_t buf[3];
     auto res = read((uint8_t*)buf, 3);
-    auto ret = res && (buf[0] != last_status[0] || buf[1] != last_status[1] || buf[2] != last_status[2]);
     auto x = buf[0];
     auto y =  buf[1];
     map_value(x, y);
+    auto ret = res && (x != last_status[0] || buf[1] != y || buf[2] != last_status[2]);
+    if (!ret) {
+      return false;
+    }
     last_status[0] = x;
     last_status[1] = y;
     last_status[2] = buf[2];

--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -167,10 +167,16 @@ public:
     uint8_t buf[3];
     auto res = read((uint8_t*)buf, 3);
     auto ret = res && (buf[0] != last_status[0] || buf[1] != last_status[1] || buf[2] != last_status[2]);
-    last_status[0] = buf[0];
-    last_status[1] = buf[1];
+    auto x = buf[0];
+    auto y =  buf[1];
+    map_value(x, y);
+    last_status[0] = x;
+    last_status[1] = y;
     last_status[2] = buf[2];
     return ret;
+  }
+  void setDeadZone(uint8_t dz_th) {
+    _dz_threshold = dz_th;
   }
   PinStatus isPressed() {
     return last_status[2] ? HIGH : LOW;
@@ -189,7 +195,14 @@ public:
     }
     return 0xFF;
   }
+  void map_value(uint8_t &x, uint8_t &y) {
+    if (x > 128 - _dz_threshold &&  x < 128 + _dz_threshold && y > 128 - _dz_threshold && y < 128 + _dz_threshold) {
+        x = 128;
+        y = 128;
+    }
+  }
 private:
+  uint8_t _dz_threshold = 26;
   uint8_t last_status[3];
 protected:
   uint8_t match[1] ={ 0x58 };  // same as fw main.c


### PR DESCRIPTION
Added support for deadzone on joystick due to rest position drift,, this will allows to set the deadzone threshold expressed as ADC levels.
In accord with these changes, the deadzone defines a region of space, where the joystick position is returned as (0,0) in range:
-  X :=[-127,128]
-  Y:= [-127,128],
This region can be identified as a square over the rest position of the stick.
changing the dz_threshold change the size of the space of where the value is approximated to (x,y) = (0,0)