### PR TITLE
fix: error if nano esp32 and selected Arduino pin number

### DIFF
--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -4,6 +4,11 @@
 #ifndef ARDUINO_LIBRARIES_MODULINO_H
 #define ARDUINO_LIBRARIES_MODULINO_H
 
+#if defined(ESP32) && defined(BOARD_HAS_PIN_REMAP) && defined(tone)
+  #error "The current configuration is unsupported, switch Pin Numbering to "By GPIO number" or #undef tone and #undef noTone in the beginning of your sketch."
+  #error "Learn more at: https://support.arduino.cc/hc/en-us/articles/10483225565980-Select-pin-numbering-for-Nano-ESP32-in-Arduino-IDE"
+#endif
+
 #include "Wire.h"
 #include <vl53l4cd_class.h>  // from stm32duino
 #include <vl53l4ed_class.h>  // from stm32duino


### PR DESCRIPTION
Solution to fix issue #35 

Users get an error if they don't select "GPIO numbering".
In this way, `tone` and `noTone` definitions in ESP32 core are bypassed because not included