### PR TITLE
fix: UnoQ support for I2C priority function

### DIFF
--- a/src/Modulino.cpp
+++ b/src/Modulino.cpp
@@ -13,8 +13,7 @@ ModulinoColor GREEN(0, 255, 0);
 ModulinoColor VIOLET(255, 0, 255);
 ModulinoColor WHITE(255, 255, 255);
 
-#if __has_include("Arduino_LED_Matrix.h")
-#if defined(ARDUINO_UNOR4_WIFI)
+#if __has_include("Arduino_LED_Matrix.h") && defined(ARDUINO_UNOR4_WIFI)
 void __increaseI2CPriority() {
     for (int i = 0; i < 96; i++) {
         if (R_ICU->IELSR[i] == BSP_PRV_IELS_ENUM(EVENT_IIC0_TXI)) {
@@ -25,7 +24,6 @@ void __increaseI2CPriority() {
         }
     }
 }
-#endif
 #else
 void __increaseI2CPriority() {}
 #endif


### PR DESCRIPTION
## Motivation
Fix compilation failure for **UnoQ** when both _Modulino_ and _Arduino_LED_Matrix_ libraries are included.

## How to reproduce
- `Modulino 0.6.0`
- `arduino:zephyr 0.51.0`

Example sketch that triggers the error:

```cpp
#include <Modulino.h>
#include "Arduino_LED_Matrix.h"

void setup() {
  Modulino.begin();
}

void loop() {}
```

Error
```
/home/arduino/.cache/arduino/sketches/01A8778A6FDBF10D480441898938F9AD/sketch/sketch.ino.cpp.o: in function `ModulinoClass::begin(arduino::HardwareI2C&)':
/home/arduino/ArduinoApps/scratch-arduino-app/sketch/Arduino_Modulino/src/Modulino.h:46: undefined reference to `__increaseI2CPriority()'
collect2: error: ld returned 1 exit status
```

Root Cause

_Modulino.cpp_ incorrectly handles the conditional logic for defining ___increaseI2CPriority_.
When _Arduino_LED_Matrix.h_ is included but ARDUINO_UNOR4_WIFI is not defined (e.g., compiling for UnoQ), neither branch provides a definition for the function, resulting in an undefined reference.

## Fix
Ensure that there is always at least one definition of `__increaseI2CPriority`.  If UnoQ the void definition is added.

