### PR TITLE
Add temperature units

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -149,7 +149,7 @@ Represents a Modulino Thermo module.
   Returns the humidity reading.
 
 - **`float getTemperature()`**  
-  Returns the temperature reading.
+  Returns the temperature reading in Celsius.
 
 ---
 


### PR DESCRIPTION
The unit of the values returned by `getTemperature()` was not listed.  I confirmed empirically that the sensor returns the temperature in units of Celsius.