### PR TITLE
Adding Modulino Display

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
 | `class` [`ModulinoMovement`](#modulinomovement) | Handles the functionality of Modulino Movement,interfacing with the IMU sensor to get acceleration readings. |
 | `class` [`ModulinoThermo`](#modulinothermo) | Handles the functionality of Modulino Thermo, managing temperature sensors to provide real-time temperature and humidity readings.                                |
 | `class` [`ModulinoDistance`](#modulinodistance) | Handles the functionality of Modulino Distance, enabling distance measurement using ToF (Time-of-Flight) sensors for precise range detection. |
+| `class` [`ModulinoDisplay`](#modulinodisplay) | Handles the functionality of Modulino Display, managing OLED screen output for text and graphics display. |
 
 ### ModulinoClass
 
@@ -166,6 +167,16 @@ Represents a Modulino Distance module.
 - **`float get()`**  
   Returns the distance measured by the sensor in millimeters.  
   The measured distance in millimeters if available, `NAN` if the distance reading is invalid.
+
+---
+
+### ModulinoDisplay
+
+Represents a Modulino Display module.
+
+#### Methods
+
+Refer to the [ArduinoGraphics](https://github.com/arduino-libraries/ArduinoGraphics) class methods for specific drawing operations such as shapes, text, colors, and pixel manipulation.
 
 ## Constants
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,6 +19,7 @@ The **Modulino** library supports the following hardware modules:
 - **Motion (`ModulinoMovement`)**: Interface with the LSM6DSOX IMU sensor to get acceleration values.
 - **Temperature & Humidity (`ModulinoThermo`)**: Get temperature and humidity readings from the HS300x sensor.
 - **Distance (`ModulinoDistance`)**: Measures distance using a Time-of-Flight (ToF) sensor (VL53L0x).
+- **Display (`ModulinoDisplay`)**: Control a 128x64 OLED display for visual output.
 
 ## Library Initialization
 
@@ -114,6 +115,20 @@ Measures distance using a ToF (Time-of-Flight) sensor.
 ModulinoDistance distance;
 distance.begin();
 float distanceValue = distance.get();
+```
+
+### ModulinoDisplay
+Controls a 128x64 OLED display for visual output. You can draw text, shapes, and images on the screen using the [ArduinoGraphics](https://github.com/arduino-libraries/ArduinoGraphics) functions.
+
+```cpp
+ModulinoDisplay display;
+display.begin();
+display.beginDraw();
+display.background(0, 0, 0);
+display.stroke(255, 255, 255);
+display.textFont(Font_5x7);
+display.text("Hello Modulino!", 10, 10);
+display.endDraw();
 ```
 
 ## Example Usage

--- a/examples/Modulino_Display/Display_Basic/Display_Basic.ino
+++ b/examples/Modulino_Display/Display_Basic/Display_Basic.ino
@@ -1,0 +1,27 @@
+#include <Arduino_Modulino.h>
+
+ModulinoDisplay display;
+
+void setup() {
+    Serial.begin(115200);
+    Modulino.begin();
+
+    if (!display.begin()) {
+        Serial.println("Display not found!");
+        while (1);
+    }
+
+    display.beginDraw();
+    display.background(0, 0, 0);
+    display.stroke(255, 255, 255);
+    display.textFont(Font_5x7);
+
+    display.text("Hello Modulino!", 10, 10);
+    display.noFill();
+    display.circle(64, 40, 15);
+
+    display.endDraw();
+}
+
+void loop() {
+}


### PR DESCRIPTION
Adding Modulino Display support. 
It relies on the [Arduino_ST7315](https://github.com/leonardocavagnis/Arduino_ST7315) library, which needs to be moved under the [arduino-libraries](https://github.com/arduino-libraries) organization.