### PR TITLE
Fix ModulinoLight::update() return value

### DIFF
--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -736,11 +736,8 @@ public:
     auto ret = _light->readAllSensors(r, g, b, rawlux, lux, ir);
     if (hubPort != nullptr) {
       hubPort->clear();
-    }
-    if (ret == 1) {
-      return true;
-    }
-    return false;
+    } 
+    return ret == 1;
   }
   ModulinoColor getColor() {
     return ModulinoColor(r, g, b);

--- a/src/Modulino.h
+++ b/src/Modulino.h
@@ -727,16 +727,20 @@ public:
     return (initialized != 0);
   }
   bool update() {
-    if (initialized) {
-      if (hubPort != nullptr) {
-        hubPort->select();
-      }
-      auto ret = _light->readAllSensors(r, g, b, rawlux, lux, ir);
-      if (hubPort != nullptr) {
-        hubPort->clear();
-      }
+    if (!initialized) {
+      return false;
     }
-    return 0;
+    if (hubPort != nullptr) {
+      hubPort->select();
+    }
+    auto ret = _light->readAllSensors(r, g, b, rawlux, lux, ir);
+    if (hubPort != nullptr) {
+      hubPort->clear();
+    }
+    if (ret == 1) {
+      return true;
+    }
+    return false;
   }
   ModulinoColor getColor() {
     return ModulinoColor(r, g, b);


### PR DESCRIPTION
`ModulinoLight::update()` was always returning `false` regardless of the outcome of the operation - and was also producing an unused variable warning:
```
In file included from /private/var/folders/n2/m12yxj811y73htmy3m6trxy40000gq/T/.arduinoIDE-unsaved2026421-16859-1vvq0h7.ckwo/Light_Basic/Light_Basic.ino:1:
/Users/tajozsi/Documents/Arduino/libraries/Arduino_Modulino/src/Modulino.h: In member function 'bool ModulinoLight::update()':
/Users/tajozsi/Documents/Arduino/libraries/Arduino_Modulino/src/Modulino.h:734:12: warning: unused variable 'ret' [-Wunused-variable]
  734 |       auto ret = _light->readAllSensors(r, g, b, rawlux, lux, ir);
      |            ^~~
```
Return value is now used to determine the return value of `ModulinoLight::update()` which also gets rid of the unused variable warning.

Tested and working on a Nano Matter with Light_Basic.ino.