### PR TITLE
Modulino Motors: Add constructor for hub and steps per revolution

### DIFF
--- a/examples/Modulino_Motors/Motors_Stepper_RPM/Motors_Stepper_RPM.ino
+++ b/examples/Modulino_Motors/Motors_Stepper_RPM/Motors_Stepper_RPM.ino
@@ -19,7 +19,11 @@ ModulinoMotors motors(200);
 void setup() {
   Serial.begin(9600);
   Modulino.begin();
-  motors.begin();
+  
+  if(!motors.begin()) {
+    Serial.println("Motors module not found!");
+    while(1);
+  }
 
   motors.setStepperModeEnabled(true);
   // Half stepping provides smoother motion by using twice as many steps per revolution, 

--- a/src/ModulinoMotors.h
+++ b/src/ModulinoMotors.h
@@ -62,6 +62,17 @@ public:
 			_stepsPerRevolution(stepsPerRevolution) {}
 
 	/**
+	 * @brief Construct a Modulino Motors instance using default address.
+	 * @param hubPort Hub port selector.
+	 * @param stepsPerRevolution Full-step motor steps per shaft revolution.
+	 */
+	ModulinoMotors(ModulinoHubPort* hubPort, int stepsPerRevolution)
+		: Module(0xFF, "MOTORS", hubPort),
+			_stepsPerRevolution((stepsPerRevolution >= 1 && stepsPerRevolution <= 32767)
+				? static_cast<int16_t>(stepsPerRevolution)
+				: static_cast<int16_t>(-1)) {}
+
+	/**
 	 * @brief Discover the motors module on known addresses.
 	 * @return Detected address encoding, or 0xFF if not found.
 	 */


### PR DESCRIPTION
This pull request improves the robustness and usability of the motors module initialization and expands the ways a `ModulinoMotors` object can be constructed. Namely you can use a hub plus steps-per-revolution and leave the address at its default value:
```cpp
// Uses default address and a hub port, with 200 full-steps/rev.
ModulinoHub hub;
ModulinoMotors motors(hub.port(0), 200);
```