### PR TITLE
Examples: Adjust `HardwareI2C` object for target board in "AddressChanger"

### DIFF
--- a/examples/Utilities/AddressChanger/AddressChanger.ino
+++ b/examples/Utilities/AddressChanger/AddressChanger.ino
@@ -1,14 +1,14 @@
 /*
  * Modulino - Address Changer
- * 
+ *
  * This utility allows you to change the I2C addresses of Modulino modules.
  * This is essential when you want to use multiple modules of the same type
  * on the same I2C bus (e.g., multiple encoders or buttons).
- * 
+ *
  * By default, each Modulino type has a fixed default I2C address. If you connect
  * two modules of the same type, they will conflict. This tool lets you change
  * the address to avoid conflicts.
- * 
+ *
  * How to use:
  * 1. Connect the Arduino and open the Serial Monitor (115200 baud)
  * 2. The tool will show all detected Modulino devices with their addresses
@@ -17,13 +17,13 @@
  *    - "0x3E 0x3F" - Changes device at 0x3E to address 0x3F
  *    - "0x3E 0" - Resets device at 0x3E to its default address
  *    - "0 0" - Resets ALL devices to their default addresses (broadcast)
- * 
+ *
  * IMPORTANT NOTES:
  * - Valid I2C addresses range from 0x08 to 0x77
  * - Some devices have fixed addresses and cannot be changed (Distance, Thermo, Movement)
  * - The new address is stored in the module's memory permanently
  * - After changing addresses, power cycle the modules to ensure changes take effect
- * 
+ *
  * Default addresses by module type:
  * - Buzzer: 0x1E (pinstrap 0x3C)
  * - Joystick: 0x2C (pinstrap 0x58)
@@ -36,7 +36,7 @@
  * - Thermo: 0x44 (fixed, cannot change)
  * - Movement: 0x6A or 0x6B (fixed, cannot change)
  *
- * This example code is in the public domain. 
+ * This example code is in the public domain.
  * Copyright (c) 2025 Arduino
  * SPDX-License-Identifier: MPL-2.0
  */
@@ -88,7 +88,7 @@ void loop() {
     // Parse the hexadecimal strings to integer values
     int num1 = parseHex(hex1);  // Current address
     int num2 = parseHex(hex2);  // New address
-    
+
     // Validate input
     if (num1 == -1 || num2 == -1) {
       Serial.println("Error: Incomplete or invalid input. Please enter two hexadecimal numbers");

--- a/examples/Utilities/AddressChanger/AddressChanger.ino
+++ b/examples/Utilities/AddressChanger/AddressChanger.ino
@@ -41,7 +41,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-#include "Wire.h"
+#include <Arduino_Modulino.h>
+
+Module module;
 
 // Structure to store information about detected Modulino devices
 struct DetectedModulino {
@@ -57,8 +59,8 @@ int numRows = 0;  // Number of devices currently detected
 
 
 void setup() {
-  // Initialize I2C communication on Wire1 interface
-  Wire1.begin();
+  // Initialize Modulino communication
+  Modulino.begin();
   // Initialize serial communication at 115200 baud
   Serial.begin(115200);
 
@@ -142,9 +144,9 @@ bool updateI2cAddress(int curAddress, int newAddress) {
   if (newAddress == 0) Serial.print(" (default address)");
   Serial.print("...");
 
-  Wire1.beginTransmission(curAddress);
-  Wire1.write(data, 40);
-  Wire1.endTransmission();
+  module.getWire()->beginTransmission(curAddress);
+  module.getWire()->write(data, 40);
+  module.getWire()->endTransmission();
 
   delay(500);
 
@@ -152,8 +154,8 @@ bool updateI2cAddress(int curAddress, int newAddress) {
     Serial.println(" done\n");
     return true;
   } else {
-    Wire1.requestFrom(newAddress, 1);
-    if (Wire1.available()) {
+    module.getWire()->requestFrom(newAddress, 1);
+    if (module.getWire()->available()) {
       Serial.println(" done\n");
       return true;
     } else {
@@ -197,8 +199,8 @@ void discoverDevices() {
 
   // Discover all modulino devices connected to the I2C bus.
   for (int addr = 0; addr < 128; addr++) {
-    Wire1.beginTransmission(addr);
-    if (Wire1.endTransmission() != 0) continue;
+    module.getWire()->beginTransmission(addr);
+    if (module.getWire()->endTransmission() != 0) continue;
 
     if (numRows >= MAX_DEVICES) {
       Serial.println("Too many devices connected, maximum supported is" + String(MAX_DEVICES));
@@ -215,15 +217,15 @@ void discoverDevices() {
 
     {
       uint8_t pinstrap = 0;           // Variable to store the pinstrap (device type)
-      Wire1.beginTransmission(addr);  // Begin I2C transmission to the current address
-      Wire1.write(0x00);              // Send a request to the device (assuming 0x00 is the register for device type)
-      Wire1.endTransmission();        // End transmission
+      module.getWire()->beginTransmission(addr);  // Begin I2C transmission to the current address
+      module.getWire()->write((int8_t)0x00);              // Send a request to the device (assuming 0x00 is the register for device type)
+      module.getWire()->endTransmission();        // End transmission
 
       delay(50);  // Delay to allow for the device to respond
 
-      Wire1.requestFrom(addr, 1);  // Request 1 byte from the device at the current address
-      if (Wire1.available()) {
-        pinstrap = Wire1.read();  // Read the device type (pinstrap)
+      module.getWire()->requestFrom(addr, 1);  // Request 1 byte from the device at the current address
+      if (module.getWire()->available()) {
+        pinstrap = module.getWire()->read();  // Read the device type (pinstrap)
       } else {
         // If an error happens in the range 0x78 to 0x7F, ignore it.
         if (addr >= 0x78) continue;


### PR DESCRIPTION
Previously the use of the `Wire1` object was hardcoded into the AddressChanger example sketch. This meant it would not function when used with boards such as the Nesso N1 that have the Qwiic connector on I2C buses associated with a different object:

https://docs.arduino.cc/tutorials/nesso-n1/user-manual/#i2c:~:text=On%20the%20Nesso%20N1%2C%20all,object.

The code is hereby updated to automatically use the default `HardwareI2C` object configured in the library codebase. In the event the default is not appropriate for a user's specific configuration, they can now easily configure the appropriate object via [the argument to the sketch's `Modulino.begin` call](https://github.com/arduino-libraries/Arduino_Modulino/blob/main/docs/api.md#methods).

This follows the approach established in the "FirmwareUpdater" sketch:

https://github.com/arduino-libraries/Arduino_Modulino/blob/ba7a4bab8408ce3575ab2ca46ae52b924049da1f/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino#L61

---

Originally reported at https://forum.arduino.cc/t/how-can-i-cange-i2c-adreess-on-modulino-latch-relay/1452068