### PR TITLE
Make firmware updater and address changer more robust

### DIFF
--- a/examples/Utilities/AddressChanger/AddressChanger.ino
+++ b/examples/Utilities/AddressChanger/AddressChanger.ino
@@ -11,12 +11,13 @@
  *
  * How to use:
  * 1. Connect the Arduino and open the Serial Monitor (115200 baud)
- * 2. The tool will show all detected Modulino devices with their addresses
- * 3. Enter commands in this format: "current_address new_address"
- *    Examples:
- *    - "0x3E 0x3F" - Changes device at 0x3E to address 0x3F
- *    - "0x3E 0" - Resets device at 0x3E to its default address
- *    - "0 0" - Resets ALL devices to their default addresses (broadcast)
+ * 2. The tool lists all detected Modulino devices with an index number
+ * 3. Enter the index of the device whose address you want to change,
+ *    or 0 to reset ALL connected devices to their default address
+ * 4. Enter the new address in hex (e.g. "0x30"), or 0 to reset that
+ *    device to its default address
+ * 5. The tool re-reads the pinstrap byte at the new address to confirm
+ *    the change was applied to the right device
  *
  * IMPORTANT NOTES:
  * - Valid I2C addresses range from 0x08 to 0x77
@@ -24,305 +25,275 @@
  * - The new address is stored in the module's memory permanently
  * - After changing addresses, power cycle the modules to ensure changes take effect
  *
- * Default addresses by module type:
- * - Buzzer: 0x1E (pinstrap 0x3C)
- * - Joystick: 0x2C (pinstrap 0x58)
- * - Buttons: 0x3E (pinstrap 0x7C)
- * - Opto Relay: 0x14 (pinstrap 0x28)
- * - Encoder: 0x3B or 0x3A (pinstrap 0x76 or 0x74)
- * - Smartleds: 0x36 (pinstrap 0x6C)
- * - Vibro: 0x38 (pinstrap 0x70)
- * - Distance: 0x29 (fixed, cannot change)
- * - Thermo: 0x44 (fixed, cannot change)
- * - Movement: 0x6A or 0x6B (fixed, cannot change)
- *
  * This example code is in the public domain.
  * Copyright (c) 2025 Arduino
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include <Arduino_Modulino.h>
+#include <ModulinoScanner.h>
 
-Module module;
+// --- I2C addressing ---
+constexpr uint8_t MIN_CONFIGURABLE_ADDRESS = 0x08;  ///< Lowest address accepted by module firmware.
+constexpr uint8_t MAX_CONFIGURABLE_ADDRESS = 0x77;  ///< Highest address accepted by module firmware.
+constexpr uint8_t USE_DEFAULT_ADDRESS      = 0x00;  ///< Value the user enters to mean "use the default address".
+constexpr uint8_t BROADCAST_ADDRESS        = 0x00;  ///< I2C address every configurable module listens on.
 
-// Structure to store information about detected Modulino devices
-struct DetectedModulino {
-  uint8_t addr;           // Current I2C address
-  String modulinoType;    // Type of module (e.g., "Buzzer", "Encoder")
-  String pinstrap;        // Pinstrap value (identifies device type)
-  String defaultAddr;     // Default address for this module type
+/** @brief Converts a pinstrap byte to the default I2C address it encodes (pinstrap == address * 2). */
+constexpr uint8_t pinstrapToDefaultAddress(uint8_t pinstrap) { return pinstrap / 2; }
+/** @brief Converts an I2C address to the pinstrap-style value the change-address command expects. */
+constexpr uint8_t addressToPinstrap(uint8_t address) { return address * 2; }
+
+// --- Change-address I2C command ---
+// Modules recognize a "CF" header followed by the new address encoded in
+// pinstrap form, zero-padded to fill a fixed-length frame.
+constexpr uint8_t ADDRESS_CHANGE_CMD_HEADER[2]        = { 'C', 'F' };
+constexpr size_t  ADDRESS_CHANGE_CMD_FRAME_LEN         = 40;
+constexpr unsigned long ADDRESS_CHANGE_APPLY_DELAY_MS = 500;  ///< Time for a module to store and apply its new address.
+
+// --- Serial / scan timing ---
+constexpr unsigned long SERIAL_BAUD_RATE          = 115200;
+constexpr unsigned long SERIAL_STABILIZE_DELAY_MS = 100;
+constexpr unsigned long NO_DEVICES_RETRY_DELAY_MS = 2000;
+
+// --- Objects ---
+Module modulino;
+ModulinoScanner scanner;
+
+// --- State machine ---
+enum State {
+  INIT,
+  SCAN_DEVICES,
+  WAIT_DEVICE_CHOICE,
+  WAIT_BROADCAST_CONFIRM,
+  WAIT_NEW_ADDRESS,
+  APPLY_ADDRESS_CHANGE
 };
 
-#define MAX_DEVICES 16
-DetectedModulino rows[MAX_DEVICES];  // Array to store detected devices
-int numRows = 0;  // Number of devices currently detected
+State state = INIT;
 
+int selectedDeviceIndex = -1;  ///< Index into scanner.devices for the device being changed, or -1 while broadcasting.
+uint8_t sourceAddress = 0;     ///< Current address of the device being changed (or BROADCAST_ADDRESS).
+uint8_t targetAddress = 0;     ///< New address to apply.
+uint8_t expectedPinstrap = 0;  ///< Pinstrap byte expected at targetAddress after a successful change, 0 to skip verification.
 
-void setup() {
-  // Initialize Modulino communication
-  Modulino.begin();
-  // Initialize serial communication at 115200 baud
-  Serial.begin(115200);
+// --- State handlers ---
 
-  // Wait for serial port to initialize
-  while (!Serial) {};
-
-  // Scan I2C bus and display all detected Modulino devices
-  discoverDevices();
+void handleInit() {
+  if (Serial) state = SCAN_DEVICES;
 }
 
-bool waitingInput = false;
+void handleScanDevices() {
+  Serial.println("\nScanning for connected Modulino devices...");
+  scanner.discover();
 
-void loop() {
-  // If no devices detected, nothing to do
-  if (numRows == 0) return;
-  // If waiting for input and nothing available, keep waiting
-  if (Serial.available() == 0 && waitingInput) return;
-
-  // Process user input when available
-  if (Serial.available() > 0) {
-    // Read two hexadecimal values separated by space
-    String hex1 = Serial.readStringUntil(' ');   // Current address
-    String hex2 = Serial.readStringUntil('\n');  // New address
-    // Echo back what user entered
-    Serial.println("> " + hex1 + " " + hex2);
-
-    // Parse the hexadecimal strings to integer values
-    int num1 = parseHex(hex1);  // Current address
-    int num2 = parseHex(hex2);  // New address
-
-    // Validate input
-    if (num1 == -1 || num2 == -1) {
-      Serial.println("Error: Incomplete or invalid input. Please enter two hexadecimal numbers");
-      return;
-    }
-
-    // Attempt to update the I2C address
-    bool success = updateI2cAddress(num1, num2);
-    if (!success) return;  // If update failed, wait for new input
-
-    // Re-scan devices to show updated addresses
-    discoverDevices();
-    waitingInput = false;
+  if (scanner.numDevices == 0) {
+    Serial.println("No Modulino devices found.");
+    delay(NO_DEVICES_RETRY_DELAY_MS);
+    return;  // Stay in SCAN_DEVICES and try again.
   }
 
-  // Display instructions for the user
-  Serial.println("Enter the current address, space, and new address (ex. \"0x20 0x30\" or \"20 2A\"):");
-  Serial.println("  - Enter \"<addr> 0\" to reset the device at <addr> to its default address.");
-  Serial.println("  - Enter \"0 0\" to reset all devices to the default address.");
-  waitingInput = true;
+  scanner.printDevices(true);
+  Serial.print("\nEnter the number of the Modulino to change (1-");
+  Serial.print(scanner.numDevices);
+  Serial.println("), or 0 to reset ALL devices to their default address:");
+
+  state = WAIT_DEVICE_CHOICE;
 }
 
-// Updates the device at current address to new address. Supports broadcasting and setting default address (0).
-// Returns true if the update was successful, false otherwise.
-bool updateI2cAddress(int curAddress, int newAddress) {
-  uint8_t data[48] = { 'C', 'F', newAddress * 2 };
-  memset(data + 3, 0, sizeof(data) - 3);  // Zero the rest of the buffer.
+void handleWaitDeviceChoice() {
+  if (Serial.available() == 0) return;
 
-  // Validate the current address, it must match a detected device.
-  if (curAddress != 0 && !findRow(curAddress)) {
-    Serial.println("Error: current address 0x" + String(curAddress, HEX) + " not found in the devices list\n");
-    return false;
+  String input = Serial.readStringUntil('\n');
+  input.trim();
+  if (input.length() == 0) return;
+
+  if (!isDecimalNumber(input)) {
+    Serial.print("Invalid input. Enter a number between 0 and ");
+    Serial.print(scanner.numDevices);
+    Serial.println(":");
+    return;
   }
 
-  if (curAddress != 0 && isFixedAddrDevice(curAddress)) {
-    Serial.println("Error: address 0x" + String(curAddress, HEX) + " is a non configurable device\n");
-    return false;
+  int choice = input.toInt();
+
+  if (choice == 0) {
+    Serial.println("This will reset ALL connected devices to their default address. Proceed? [y/n]");
+    state = WAIT_BROADCAST_CONFIRM;
+    return;
   }
 
-  // Validate the new address.
-  if (newAddress != 0 && (newAddress < 8 || newAddress > 0x77)) {
-    Serial.println("Error: new address 0x" + String(newAddress, HEX) + " must be from 0x08 to 0x77\n");
-    return false;
+  if (choice < 1 || choice > scanner.numDevices) {
+    Serial.print("Invalid selection. Enter a number between 0 and ");
+    Serial.print(scanner.numDevices);
+    Serial.println(":");
+    return;
   }
 
-  if (curAddress == 0) {
-    Serial.print("Updating all devices (broadcast 0x00) to 0x" + String(newAddress, HEX));
+  const DetectedModulino& device = scanner.devices[choice - 1];
+  if (device.isFixed) {
+    Serial.println("That device has a fixed address and cannot be changed. Choose another:");
+    return;
+  }
+
+  selectedDeviceIndex = choice - 1;
+  sourceAddress = device.addr;
+
+  Serial.print("Selected ");
+  Serial.print(device.modulinoType);
+  Serial.print(" at 0x");
+  Serial.println(device.addr, HEX);
+  Serial.print("Enter the new address in hex (e.g. \"0x30\"), or 0 to reset to its default address (0x");
+  Serial.print(pinstrapToDefaultAddress(device.pinstrapValue), HEX);
+  Serial.println("):");
+
+  state = WAIT_NEW_ADDRESS;
+}
+
+void handleWaitBroadcastConfirm() {
+  if (Serial.available() == 0) return;
+
+  String input = Serial.readStringUntil('\n');
+  input.trim();
+  if (input.length() == 0) return;
+
+  if (input.equalsIgnoreCase("y")) {
+    selectedDeviceIndex = -1;
+    sourceAddress = BROADCAST_ADDRESS;
+    targetAddress = USE_DEFAULT_ADDRESS;
+    expectedPinstrap = 0;  // Multiple devices reset at once; nothing to verify.
+    state = APPLY_ADDRESS_CHANGE;
   } else {
-    Serial.print("Updating the device address from 0x" + String(curAddress, HEX) + " to 0x" + String(newAddress, HEX));
+    Serial.println("Cancelled.");
+    state = SCAN_DEVICES;
   }
-  if (newAddress == 0) Serial.print(" (default address)");
+}
+
+void handleWaitNewAddress() {
+  if (Serial.available() == 0) return;
+
+  String input = Serial.readStringUntil('\n');
+  int newAddress = parseHexAddress(input);
+
+  if (newAddress == -1) {
+    Serial.println("Error: enter a valid hexadecimal address, or 0 for the default. Try again:");
+    return;
+  }
+
+  if (newAddress != USE_DEFAULT_ADDRESS && (newAddress < MIN_CONFIGURABLE_ADDRESS || newAddress > MAX_CONFIGURABLE_ADDRESS)) {
+    Serial.print("Error: address must be between 0x");
+    Serial.print(MIN_CONFIGURABLE_ADDRESS, HEX);
+    Serial.print(" and 0x");
+    Serial.print(MAX_CONFIGURABLE_ADDRESS, HEX);
+    Serial.println(". Try again:");
+    return;
+  }
+
+  const DetectedModulino& device = scanner.devices[selectedDeviceIndex];
+  targetAddress = (newAddress == USE_DEFAULT_ADDRESS) ? pinstrapToDefaultAddress(device.pinstrapValue) : (uint8_t)newAddress;
+  expectedPinstrap = device.pinstrapValue;
+
+  state = APPLY_ADDRESS_CHANGE;
+}
+
+void handleApplyAddressChange() {
+  bool isBroadcast = (selectedDeviceIndex == -1);
+
+  Serial.print("Updating ");
+  Serial.print(isBroadcast ? "all devices (broadcast)" : "the device");
+  Serial.print(" to address 0x");
+  Serial.print(targetAddress, HEX);
   Serial.print("...");
 
-  module.getWire()->beginTransmission(curAddress);
-  module.getWire()->write(data, 40);
-  module.getWire()->endTransmission();
+  sendAddressChangeCommand(sourceAddress, targetAddress);
+  delay(ADDRESS_CHANGE_APPLY_DELAY_MS);
 
-  delay(500);
-
-  if (newAddress == 0) {
-    Serial.println(" done\n");
-    return true;
+  if (isBroadcast) {
+    Serial.println(" done");
+  } else if (confirmAddressChange(targetAddress, expectedPinstrap)) {
+    Serial.println(" done, verified");
   } else {
-    module.getWire()->requestFrom(newAddress, 1);
-    if (module.getWire()->available()) {
-      Serial.println(" done\n");
-      return true;
-    } else {
-      Serial.println(" error\n");
-      return false;
-    }
+    Serial.println(" failed: could not confirm the device at the new address");
   }
+
+  selectedDeviceIndex = -1;
+  state = SCAN_DEVICES;
 }
 
-// Function to parse hex number (with or without 0x prefix)
-int parseHex(String hexStr) {
-  hexStr.trim();
+// --- I2C helpers ---
 
-  if (hexStr.length() == 0) {
-    return -1;
+// Sends the "CF" change-address command to currentAddress, telling the module to
+// switch to newAddress (or reset to its default address when newAddress is 0).
+void sendAddressChangeCommand(uint8_t currentAddress, uint8_t newAddress) {
+  uint8_t frame[ADDRESS_CHANGE_CMD_FRAME_LEN] = {
+    ADDRESS_CHANGE_CMD_HEADER[0],
+    ADDRESS_CHANGE_CMD_HEADER[1],
+    addressToPinstrap(newAddress)
+  };
+  memset(frame + 3, 0, sizeof(frame) - 3);  // Zero the rest of the frame.
+
+  modulino.getWire()->beginTransmission(currentAddress);
+  modulino.getWire()->write(frame, ADDRESS_CHANGE_CMD_FRAME_LEN);
+  modulino.getWire()->endTransmission();
+}
+
+// Reads the pinstrap byte back from newAddress and checks it matches the device
+// that was there before the change, confirming the right module moved.
+bool confirmAddressChange(uint8_t newAddress, uint8_t expectedPinstrap) {
+  modulino.getWire()->requestFrom(newAddress, (uint8_t)1);
+  if (!modulino.getWire()->available()) return false;
+  return modulino.getWire()->read() == expectedPinstrap;
+}
+
+// --- Input parsing helpers ---
+
+bool isDecimalNumber(const String& str) {
+  for (unsigned int i = 0; i < str.length(); i++) {
+    if (!isDigit(str.charAt(i))) return false;
   }
+  return true;
+}
+
+bool isHexadecimalChar(char c) {
+  return ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'));
+}
+
+// Parses a hex address string (with or without a "0x" prefix). Returns -1 if invalid.
+int parseHexAddress(String hexStr) {
+  hexStr.trim();
+  if (hexStr.length() == 0) return -1;
 
   if (hexStr.startsWith("0x") || hexStr.startsWith("0X")) {
-    hexStr = hexStr.substring(2);  // Remove the "0x" prefix
+    hexStr = hexStr.substring(2);
   }
 
-  // Validate that the remaining string contains only valid hexadecimal characters (0-9, A-F, a-f)
-  for (int i = 0; i < hexStr.length(); i++) {
-    if (!isHexDigit(hexStr.charAt(i))) {
-      return -1;
-    }
+  for (unsigned int i = 0; i < hexStr.length(); i++) {
+    if (!isHexadecimalChar(hexStr.charAt(i))) return -1;
   }
 
   return strtol(hexStr.c_str(), NULL, 16);
 }
 
-bool isHexDigit(char c) {
-  return ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'));
+// --- Arduino entry points ---
+
+void setup() {
+  Serial.begin(SERIAL_BAUD_RATE);
+  while (!Serial) {}
+  delay(SERIAL_STABILIZE_DELAY_MS);  // Allow serial port to stabilize.
+
+  Modulino.begin();
+  scanner.begin(*modulino.getWire());
+
+  state = INIT;
 }
 
-void discoverDevices() {
-  char buffer[64];
-  Serial.println("ADDR\tMODULINO\tPINSTRAP\tDEFAULT ADDR");  // Table heading.
-
-  numRows = 0;
-
-  // Discover all modulino devices connected to the I2C bus.
-  for (int addr = 0; addr < 128; addr++) {
-    module.getWire()->beginTransmission(addr);
-    if (module.getWire()->endTransmission() != 0) continue;
-
-    if (numRows >= MAX_DEVICES) {
-      Serial.println("Too many devices connected, maximum supported is" + String(MAX_DEVICES));
-      return;
-    }
-
-    // Some addresses represent non configurable devices (no MCU on it). Handle them as a special case.
-    if (isFixedAddrDevice(addr)) {
-      snprintf(buffer, 64, "0x%02X (cannot change)", addr);
-      addRow(addr, fixedAddrToName(addr), "-", String(buffer));
-
-      continue;  // Stop here, do not try to communicate with this device.
-    }
-
-    {
-      uint8_t pinstrap = 0;           // Variable to store the pinstrap (device type)
-      module.getWire()->beginTransmission(addr);  // Begin I2C transmission to the current address
-      module.getWire()->write((int8_t)0x00);              // Send a request to the device (assuming 0x00 is the register for device type)
-      module.getWire()->endTransmission();        // End transmission
-
-      delay(50);  // Delay to allow for the device to respond
-
-      module.getWire()->requestFrom(addr, 1);  // Request 1 byte from the device at the current address
-      if (module.getWire()->available()) {
-        pinstrap = module.getWire()->read();  // Read the device type (pinstrap)
-      } else {
-        // If an error happens in the range 0x78 to 0x7F, ignore it.
-        if (addr >= 0x78) continue;
-        Serial.println("Failed to read device type at address 0x" + String(addr, HEX));
-      }
-
-      snprintf(buffer, 64, "0x%02X", pinstrap);
-      auto hexPinstrap = String(buffer);
-
-      snprintf(buffer, 64, "0x%02X", pinstrap / 2);  // Default address is half pinstrap.
-      auto defaultAddr = String(buffer);
-      if (addr != pinstrap / 2) defaultAddr += " *";  // Mark devices with modified address.
-
-      addRow(addr, pinstrapToName(pinstrap), hexPinstrap, defaultAddr);
-    }
+void loop() {
+  switch (state) {
+    case INIT:                   handleInit(); break;
+    case SCAN_DEVICES:           handleScanDevices(); break;
+    case WAIT_DEVICE_CHOICE:     handleWaitDeviceChoice(); break;
+    case WAIT_BROADCAST_CONFIRM: handleWaitBroadcastConfirm(); break;
+    case WAIT_NEW_ADDRESS:       handleWaitNewAddress(); break;
+    case APPLY_ADDRESS_CHANGE:   handleApplyAddressChange(); break;
   }
-
-  // Print the results.
-  for (int i = 0; i < numRows; i++) {
-    char buffer[16];
-    snprintf(buffer, 16, "0x%02X", rows[i].addr);
-
-    Serial.print(fixedWidth(buffer, 8));
-    Serial.print(fixedWidth(rows[i].modulinoType, 16));
-    Serial.print(fixedWidth(rows[i].pinstrap, 16));
-    Serial.println(fixedWidth(rows[i].defaultAddr, 12));
-  }
-}
-
-void addRow(uint8_t address, String modulinoType, String pinstrap, String defaultAddr) {
-  if (numRows >= MAX_DEVICES) return;
-
-  rows[numRows].addr = address;
-  rows[numRows].modulinoType = modulinoType;
-  rows[numRows].pinstrap = pinstrap;
-  rows[numRows].defaultAddr = defaultAddr;
-  numRows++;  // Increment the row counter
-}
-
-bool findRow(uint8_t address) {
-  for (int i = 0; i < numRows; i++) {
-    if (rows[i].addr == address) return true;
-  }
-  return false;
-}
-
-
-// Function to add padding to the right to ensure each field has a fixed width
-String fixedWidth(String str, int width) {
-  for (int i = str.length(); i < width; i++) str += ' ';
-  return str;
-}
-
-String pinstrapToName(uint8_t pinstrap) {
-  switch (pinstrap) {
-    case 0x04:
-      return "Latch Relay";
-    case 0x3C:
-      return "Buzzer";
-    case 0x58:
-      return "Joystick";
-    case 0x7C:
-      return "Buttons";
-    case 0x28:
-      return "Opto Relay";
-    case 0x76:
-    case 0x74:
-      return "Encoder";
-    case 0x6C:
-      return "Smartleds";
-    case 0x70:
-      return "Vibro";
-    case 0x48:
-      return "Motors";
-  }
-  return "UNKNOWN";
-}
-
-String fixedAddrToName(uint8_t address) {
-  switch (address) {
-    case 0x29:
-      return "Distance";
-    case 0x44:
-      return "Thermo";
-    case 0x6A:
-    case 0x6B:
-      return "Movement";
-  }
-  return "UNKNOWN";
-}
-
-bool isFixedAddrDevice(uint8_t addr) {
-  // List of non-configurable devices, recognized by their fixed I2C address.
-  const uint8_t fixedAddr[] = { 0x29, 0x44, 0x6A, 0x6B };
-
-  for (int i = 0; i < sizeof(fixedAddr) / sizeof(fixedAddr[0]); i++) {
-    if (addr == fixedAddr[i]) return true;
-  }
-  return false;
 }

--- a/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino
+++ b/examples/Utilities/FirmwareUpdater/FirmwareUpdater.ino
@@ -15,7 +15,7 @@
  * 5. Wait for the update to complete before disconnecting
  * 
  * Special case for LED Matrix:
- * - Set force_led_matrix = true if programming a blank LED Matrix module
+ * - Connect only the LED Matrix and answer "y" when prompted
  * 
  * NOTE: This uses the STM32 bootloader protocol to flash firmware.
  * Do not disconnect power during the update process.
@@ -34,329 +34,279 @@
 #endif
 
 #include <Arduino_Modulino.h>
-#include "Wire.h"
+#include <ModulinoScanner.h>
+#include <ModulinoFlasher.h>
 #include "fw.h"
 #include "fw_ledmatrix.h"
-#include "fw_motors.h"
+#include <fw_motors.h>
 
-// Reference: STM32 I2C bootloader protocol documentation
-// https://www.st.com/resource/en/application_note/an4221-i2c-protocol-used-in-the-stm32-bootloader-stmicroelectronics.pdf
+// --- Firmware Registry ---
 
-bool flash(const uint8_t* binary, size_t lenght, bool verbose = true);
-Module modulino;
-
-// Change this to true if programming a blank Modulino LED Matrix
-// For all other modules, keep this false
-bool force_led_matrix = false;
-
-// Force motors firmware
-// Set this to true if you want to flash the motors firmware regardless of the detected module type
-bool force_motors = false;
-
-void setup() {
-  Serial.begin(115200);
-  // Initialize Modulino communication
-  Modulino.begin();
-  // Set I2C clock to 400kHz for faster communication
-  modulino.getWire()->setClock(400000);
-
-  // Check if module is already in bootloader mode (address 0x64)
-  modulino.getWire()->beginTransmission(0x64);
-  auto is_boot_mode = (modulino.getWire()->endTransmission() == 0);
-
-  if (is_boot_mode) {
-    Serial.println("Device alrady in bootloader mode. Waiting...");
-    // Probing the address causes a reset when in bootloader
-    delay(6500); // Give the device time to reset
-  }
-
-  bool is_led_matrix = false;
-  bool is_motors = false;
-
-  // Send reset command to module if not already in boot mode
-  // IMPORTANT: Connect only ONE module at a time
-  if (!is_boot_mode) {
-    // Check if connected module is an LED matrix (address 0x39)
-    modulino.getWire()->beginTransmission(0x39);
-    is_led_matrix = (modulino.getWire()->endTransmission() == 0);
-
-    // Check if connected module is Motors (address 0x48)
-    if (!is_led_matrix) {
-      modulino.getWire()->beginTransmission(0x48);
-      is_motors = (modulino.getWire()->endTransmission() == 0);
-    }
-
-    if (is_led_matrix) {
-      Serial.println("led matrix mode");
-    }
-    if (is_motors) {
-      Serial.println("motors mode");
-    }
-
-    // Send reset command to enter bootloader mode
-    if (sendReset() != 0) {
-      Serial.println("Send reset failed");
-    }
-  }
-
-  // Flash the appropriate firmware based on module type
-  bool result;
-  if (is_led_matrix || force_led_matrix) {
-    // Flash LED Matrix firmware
-    result = flash(matrix_node_base_bin, matrix_node_base_bin_len);
-  } else if (is_motors || force_motors) {
-    // Flash Motors firmware
-    result = flash(motors_node_base_bin, motors_node_base_bin_len);
-  } else {
-    // Flash standard Modulino firmware
-    result = flash(node_base_bin, node_base_bin_len);
-  }
-
-#if defined(ARDUINO_UNOWIFIR4)
-  // Display result on UNO R4 WiFi LED matrix
-  if (result) {
-    matrixInitAndDraw("PASS");
-  } else {
-    matrixInitAndDraw("FAIL");
-  }
-#endif
-}
-
-void loop() {
-  // put your main code here, to run repeatedly:
-}
-
-class SerialVerbose {
-public:
-  SerialVerbose(bool verbose)
-    : _verbose(verbose) {}
-  int print(String s) {
-    if (_verbose) {
-      Serial.print(s);
-    }
-  }
-  int println(String s) {
-    if (_verbose) {
-      Serial.println(s);
-    }
-  }
-  int println(int num, int base) {
-    if (_verbose) {
-      Serial.println(num, base);
-    }
-  }
-private:
-  bool _verbose;
+struct FirmwareDescriptor {
+  ModulinoFirmware type;
+  const char* name;
+  const unsigned char* binData;
+  unsigned int binLen;
 };
+
+const FirmwareDescriptor FIRMWARES[] = {
+  { FIRMWARE_GENERIC,    "Generic (Buzzer, Buttons, Encoder, ...)", node_base_bin,        node_base_bin_len },
+  { FIRMWARE_MOTORS,     "Motors",                                  motors_node_base_bin, motors_node_base_bin_len },
+  { FIRMWARE_LED_MATRIX, "LED Matrix",                              matrix_node_base_bin, matrix_node_base_bin_len }
+};
+const size_t NUM_FIRMWARES = sizeof(FIRMWARES) / sizeof(FIRMWARES[0]);
+
+// --- Objects ---
+Module modulino;
+ModulinoScanner scanner;
+ModulinoFlasher flasher(modulino);
+
+// --- State machine ---
+enum State {
+  INIT,
+  SCAN_DEVICES,
+  WAIT_USER_CHOICE,
+  WAIT_BOOT_MODE_CHOICE,
+  FLASHING,
+  DONE
+};
+
+State state = INIT;
+int selectedAddress  = -1;
+ModulinoFirmware firmwareType = FIRMWARE_GENERIC;
+
+// --- UNO R4 WiFi LED matrix helpers ---
 
 #if defined(ARDUINO_UNOWIFIR4)
 ArduinoLEDMatrix matrix;
 
-void matrixInitAndDraw(char* text) {
+/**
+ * @brief Renders a progress bar on the UNO R4 WiFi LED matrix.
+ *
+ * Lights a proportional number of the 96 LEDs (8 rows x 12 columns),
+ * filling left-to-right, top-to-bottom.
+ *
+ * @param progress Number of completed pages.
+ * @param total    Total number of pages.
+ */
+void updateProgressMatrix(int progress, int total) {
+  uint32_t frame[3] = {0, 0, 0};
+  int numLeds = (progress * 96) / total;
+  for (int i = 0; i < numLeds; i++) {
+    int row = i / 12;
+    int col = 11 - (i % 12);
+    frame[row / 4] |= (1 << (col + (3 - (row % 4)) * 12));
+  }
+  matrix.loadFrame(frame);
+}
+
+/**
+ * @brief Initialises the UNO R4 WiFi LED matrix and renders a short status string.
+ *
+ * Uses the 4x6 pixel font. Intended for "PASS" or "FAIL" messages.
+ * @param text Null-terminated string to display.
+ */
+void matrixInitAndDraw(const char* text) {
   matrix.begin();
   matrix.beginDraw();
-
   matrix.stroke(0xFFFFFFFF);
   matrix.textFont(Font_4x6);
   matrix.beginText(0, 1, 0xFFFFFF);
   matrix.println(text);
   matrix.endText();
-
   matrix.endDraw();
 }
+#else
+void updateProgressMatrix(int progress, int total) {}
+void matrixInitAndDraw(const char* text) {}
 #endif
 
-bool flash(const uint8_t* binary, size_t lenght, bool verbose) {
+// --- State Handlers ---
 
-  SerialVerbose SerialDebug(verbose);
-
-  uint8_t resp_buf[255];
-  int resp;
-  SerialDebug.println("GET_COMMAND");
-  resp = command(0, nullptr, 0, resp_buf, 20, verbose);
-
-  if (resp < 0) {
-    SerialDebug.println("Failed :(");
-    return false;
+void handleInit() {
+  if (Serial) {
+    state = SCAN_DEVICES;
   }
-
-  for (int i = 0; i < resp; i++) {
-    SerialDebug.println(resp_buf[i], HEX);
-  }
-
-  SerialDebug.println("GET_ID");
-  resp = command(2, nullptr, 0, resp_buf, 3, verbose);
-  for (int i = 0; i < resp; i++) {
-    SerialDebug.println(resp_buf[i], HEX);
-  }
-
-  SerialDebug.println("GET_ID");
-  resp = command(2, nullptr, 0, resp_buf, 3, verbose);
-  for (int i = 0; i < resp; i++) {
-    SerialDebug.println(resp_buf[i], HEX);
-  }
-
-  SerialDebug.println("MASS_ERASE");
-  uint8_t erase_buf[3] = { 0xFF, 0xFF, 0x0 };
-  resp = command(0x44, erase_buf, 3, nullptr, 0, verbose);
-  for (int i = 0; i < resp; i++) {
-    SerialDebug.println(resp_buf[i], HEX);
-  }
-
-  int lenght_mod128 = ((lenght + 128) / 128) * 128;
-  for (int i = lenght_mod128; i >= 0; i -= 128) {
-    SerialDebug.print("WRITE_PAGE ");
-    SerialDebug.println(i, HEX);
-    uint8_t write_buf[5] = { 8, 0, i / 256, i % 256 };
-    resp = command_write_page(0x32, write_buf, 5, &binary[i], 128, verbose);
-    for (int i = 0; i < resp; i++) {
-      SerialDebug.println(resp_buf[i], HEX);
-    }
-    delay(10);
-  }
-  SerialDebug.println("GO");
-  uint8_t jump_buf[5] = { 0x8, 0x00, 0x00, 0x00, 0x8 };
-  resp = command(0x21, jump_buf, 5, nullptr, 0, verbose);
-  return true;
 }
 
-int howmany;
-int command_write_page(uint8_t opcode, uint8_t* buf_cmd, size_t len_cmd, const uint8_t* buf_fw, size_t len_fw, bool verbose) {
+void handleScanDevices() {
+  // Check whether a device is already waiting in bootloader mode.
+  if (scanner.deviceInBootloaderMode()) {
+    Serial.println("A Modulino device was detected in bootloader mode.");
+    Serial.println("Which firmware to flash?");
+    for (size_t i = 0; i < NUM_FIRMWARES; i++) {
+      Serial.print("  [");
+      Serial.print(i + 1);
+      Serial.print("] ");
+      Serial.println(FIRMWARES[i].name);
+    }
+    state = WAIT_BOOT_MODE_CHOICE;
+  } else {
+    Serial.println("\nScanning for connected Modulino devices...");
+    scanner.discover();
 
-  SerialVerbose SerialDebug(verbose);
-
-  uint8_t cmd[2];
-  cmd[0] = opcode;
-  cmd[1] = 0xFF ^ opcode;
-  modulino.getWire()->beginTransmission(100);
-  modulino.getWire()->write(cmd, 2);
-  if (len_cmd > 0) {
-    buf_cmd[len_cmd - 1] = 0;
-    for (int i = 0; i < len_cmd - 1; i++) {
-      buf_cmd[len_cmd - 1] ^= buf_cmd[i];
-    }
-    modulino.getWire()->endTransmission(true);
-    modulino.getWire()->requestFrom(100, 1);
-    auto c = modulino.getWire()->read();
-    if (c != 0x79) {
-      SerialDebug.print("error first ack: ");
-      SerialDebug.println(c, HEX);
-      return -1;
-    }
-    modulino.getWire()->beginTransmission(100);
-    modulino.getWire()->write(buf_cmd, len_cmd);
-  }
-  modulino.getWire()->endTransmission(true);
-  modulino.getWire()->requestFrom(100, 1);
-  auto c = modulino.getWire()->read();
-  if (c != 0x79) {
-    while (c == 0x76) {
-      delay(10);
-      modulino.getWire()->requestFrom(100, 1);
-      c = modulino.getWire()->read();
-    }
-    if (c != 0x79) {
-      SerialDebug.print("error second ack: ");
-      SerialDebug.println(c, HEX);
-      return -1;
+    if (scanner.numDevices == 0) {
+      Serial.println("No configurable Modulinos found.");
+      delay(2000);
+      state = SCAN_DEVICES;
+    } else {
+      scanner.printDevices(true);
+      if (scanner.numDevices == 1) {
+        Serial.println("\nProceed with flashing this device? [y/n]");
+      } else {
+        Serial.print("\nEnter the number of the Modulino to flash (1-");
+        Serial.print(scanner.numDevices);
+        Serial.println("):");
+      }
+      state = WAIT_USER_CHOICE;
     }
   }
-  uint8_t tmpbuf[len_fw + 2] = { len_fw - 1 };
-  memcpy(&tmpbuf[1], buf_fw, len_fw);
-  for (int i = 0; i < len_fw + 1; i++) {
-    tmpbuf[len_fw + 1] ^= tmpbuf[i];
-  }
-  modulino.getWire()->beginTransmission(100);
-  modulino.getWire()->write(tmpbuf, len_fw + 2);
-  modulino.getWire()->endTransmission(true);
-  modulino.getWire()->requestFrom(100, 1);
-  c = modulino.getWire()->read();
-  if (c != 0x79) {
-    while (c == 0x76) {
-      delay(10);
-      modulino.getWire()->requestFrom(100, 1);
-      c = modulino.getWire()->read();
-    }
-    if (c != 0x79) {
-      SerialDebug.print("error: ");
-      SerialDebug.println(c, HEX);
-      return -1;
-    }
-  }
-final_ack:
-  return howmany + 1;
 }
 
-int command(uint8_t opcode, uint8_t* buf_cmd, size_t len_cmd, uint8_t* buf_resp, size_t len_resp, bool verbose) {
-
-  SerialVerbose SerialDebug(verbose);
-
-  uint8_t cmd[2];
-  cmd[0] = opcode;
-  cmd[1] = 0xFF ^ opcode;
-  modulino.getWire()->beginTransmission(100);
-  modulino.getWire()->write(cmd, 2);
-  if (len_cmd > 0) {
-    modulino.getWire()->endTransmission(true);
-    modulino.getWire()->requestFrom(100, 1);
-    auto c = modulino.getWire()->read();
-    if (c != 0x79) {
-      Serial.print("error first ack: ");
-      Serial.println(c, HEX);
-      return -1;
+void handleWaitBootModeChoice() {
+  if (Serial.available() > 0) {
+    String inputStr = Serial.readStringUntil('\n');
+    inputStr.trim();
+    if (inputStr.length() == 0) return;
+    
+    int choice = inputStr.toInt();
+    bool found = false;
+    
+    // Check if the choice is valid (1 to NUM_FIRMWARES)
+    if (choice >= 1 && choice <= (int)NUM_FIRMWARES) {
+      firmwareType = FIRMWARES[choice - 1].type;
+      found = true;
     }
-    modulino.getWire()->beginTransmission(100);
-    modulino.getWire()->write(buf_cmd, len_cmd);
-  }
-  modulino.getWire()->endTransmission(true);
-  modulino.getWire()->requestFrom(100, 1);
-  auto c = modulino.getWire()->read();
-  if (c != 0x79) {
-    while (c == 0x76) {
-      delay(100);
-      modulino.getWire()->requestFrom(100, 1);
-      c = modulino.getWire()->read();
-      SerialDebug.println("retry");
+    
+    if (!found) {
+      // Fallback to first firmware (generic) if input is invalid but not empty
+      firmwareType = FIRMWARES[0].type;
     }
-    if (c != 0x79) {
-      SerialDebug.print("error second ack: ");
-      SerialDebug.println(c, HEX);
-      return -1;
-    }
+    state = FLASHING;
   }
-  int howmany = -1;
-  if (len_resp == 0) {
-    goto final_ack;
-  }
-  modulino.getWire()->requestFrom(100, len_resp);
-  howmany = modulino.getWire()->read();
-  for (int j = 0; j < howmany + 1; j++) {
-    buf_resp[j] = modulino.getWire()->read();
-  }
-
-  modulino.getWire()->requestFrom(100, 1);
-  c = modulino.getWire()->read();
-  if (c != 0x79) {
-    SerialDebug.print("error: ");
-    SerialDebug.println(c, HEX);
-    return -1;
-  }
-final_ack:
-  return howmany + 1;
 }
 
-int sendReset() {
-  uint8_t buf[3] = { 'D', 'I', 'E' };
-  int ret;
-  for (int i = 0; i < 0x78; i++) {
-    modulino.getWire()->beginTransmission(i);
-    ret = modulino.getWire()->endTransmission();
-    if (ret != 2) {
-      modulino.getWire()->beginTransmission(i);
-      modulino.getWire()->write(buf, 40);
-      ret = modulino.getWire()->endTransmission();
-      return ret;
+void handleWaitUserChoice() {
+  if (Serial.available() > 0) {
+    String inputStr = Serial.readStringUntil('\n');
+    inputStr.trim();
+    if (inputStr.length() == 0) return;
+
+    const DetectedModulino* device = nullptr;
+
+    if (scanner.numDevices == 1) {
+      if (inputStr != "y" && inputStr != "Y") {
+        Serial.println("Aborted. Rescanning...");
+        delay(1000);
+        state = SCAN_DEVICES;
+        return;
+      }
+      device = &scanner.devices[0];
+    } else {
+      int index = inputStr.toInt() - 1;
+      if (index < 0 || index >= scanner.numDevices) {
+        Serial.print("Invalid selection. Enter a number between 1 and ");
+        Serial.print(scanner.numDevices);
+        Serial.println(":");
+        return;
+      }
+      device = &scanner.devices[index];
+    }
+
+    selectedAddress = device->addr;
+    Serial.print("Sending reset to device 0x");
+    Serial.println(selectedAddress, HEX);
+
+    // Look up firmware type directly from the device registry.
+    firmwareType = modulinoFirmwareForPinstrap(device->pinstrapValue);
+
+    if (flasher.enterBootloader((uint8_t)selectedAddress)) {
+      delay(250);
+      state = FLASHING;
+    } else {
+      Serial.println("Failed to send reset command to the device.");
+      state = SCAN_DEVICES;
     }
   }
-  return ret;
+}
+
+void handleFlashing() {
+  // The STM32 bootloader takes ~6500 ms to reboot after being contacted.
+  // Wait for the remaining time so the flash commands arrive when it is ready.
+  unsigned long waitMs = scanner.bootloaderReadyIn();
+  if (waitMs > 0) {
+    Serial.print("Waiting for bootloader to be ready (");
+    Serial.print(waitMs);
+    Serial.println(" ms)...");
+    delay(waitMs);
+  }
+
+  Serial.println("\nStarting firmware update...");
+
+  const FirmwareDescriptor* fw = nullptr;
+  for (size_t i = 0; i < NUM_FIRMWARES; i++) {
+    if (FIRMWARES[i].type == firmwareType) {
+      fw = &FIRMWARES[i];
+      break;
+    }
+  }
+
+  // Fallback to first firmware if type somehow not found
+  if (fw == nullptr) fw = &FIRMWARES[0];
+
+  Serial.print("Flashing Modulino ");
+  Serial.print(fw->name);
+  Serial.println(" Firmware...");
+
+  bool result = flasher.flash(fw->binData, fw->binLen, false, updateProgressMatrix);
+
+  if (result) {
+    Serial.println("\nFirmware update completed SUCCESSFULLY!");
+    matrixInitAndDraw("PASS");
+  } else {
+    Serial.println("\nFirmware update FAILED.");
+    matrixInitAndDraw("FAIL");
+  }
+  state = DONE;
+}
+
+void handleDone() {
+  /* Wait for the user to reset the board. */
+  delay(1000);
+}
+
+// --- Arduino entry points ---
+
+/**
+ * @brief Arduino setup routine.
+ *
+ * Initialises Serial, the Modulino I2C bus at 400 kHz, and (on UNO R4 WiFi)
+ * the on-board LED matrix. Sets the state machine to INIT.
+ */
+void setup() {
+  Serial.begin(115200);
+  while (!Serial);
+  delay(100);  // allow Serial to stabilise
+  Modulino.begin();
+  scanner.begin(*modulino.getWire());
+
+#if defined(ARDUINO_UNOWIFIR4)
+  matrix.begin();
+#endif
+
+  state = INIT;
+}
+
+/**
+ * @brief Arduino main loop - drives the firmware-update state machine.
+ */
+void loop() {
+  switch (state) {
+    case INIT:                  handleInit(); break;
+    case SCAN_DEVICES:          handleScanDevices(); break;
+    case WAIT_BOOT_MODE_CHOICE: handleWaitBootModeChoice(); break;
+    case WAIT_USER_CHOICE:      handleWaitUserChoice(); break;
+    case FLASHING:              handleFlashing(); break;
+    case DONE:                  handleDone(); break;
+  }
 }

--- a/src/Arduino_Modulino.h
+++ b/src/Arduino_Modulino.h
@@ -1,2 +1,3 @@
 #include "Modulino.h"
 #include "ModulinoMotors.h"
+#include "ModulinoAddresses.h"

--- a/src/ModulinoAddresses.h
+++ b/src/ModulinoAddresses.h
@@ -1,0 +1,130 @@
+#pragma once
+
+// Copyright (c) 2025 Arduino SA
+// SPDX-License-Identifier: MPL-2.0
+
+#include <stdint.h>
+#include <Arduino.h>
+
+/**
+ * @file ModulinoAddresses.h
+ * @brief Central registry of Modulino I2C addresses, device names and firmware types.
+ * All devices are stored in a single @ref MODULINO_MAP table.
+ * A non-zero @c pinstrap field marks a configurable device whose default I2C
+ * address is @c pinstrap / 2. A zero @c pinstrap marks a fixed-address device
+ * whose hard-coded address is stored in @c addr.
+ * To register a new device, append one entry to @ref MODULINO_MAP.
+ */
+
+/**
+ * @brief Firmware image required to program a Modulino device.
+ */
+enum ModulinoFirmware : uint8_t {
+  FIRMWARE_GENERIC,    ///< Standard firmware (Buzzer, Buttons, Knob, Pixels, ...).
+  FIRMWARE_MOTORS,     ///< Motors module firmware.
+  FIRMWARE_LED_MATRIX, ///< LED Matrix module firmware.
+};
+
+/**
+ * @brief Describes one entry in the unified Modulino device registry.
+ * - **Configurable device** (@c pinstrap != 0): responds to I2C address
+ *   @c pinstrap / 2 by default and can be re-addressed. The @c addr field
+ *   holds that default address for convenience.
+ * - **Fixed-address device** (@c pinstrap == 0): uses @c addr as its
+ *   permanent, non-configurable I2C address.
+ */
+struct ModulinoEntry {
+  uint8_t          addr;     ///< Default I2C address (pinstrap/2) for configurable devices, or the fixed address.
+  uint8_t          pinstrap; ///< Pinstrap byte reported by the device. @c 0 for fixed-address devices.
+  const char*      name;     ///< Human-readable device name.
+  ModulinoFirmware firmware; ///< Firmware image required to program this device.
+};
+
+/**
+ * @brief Unified lookup table of all known Modulino devices.
+ * Entries with @c pinstrap != 0 are configurable; entries with @c pinstrap == 0
+ * are fixed-address. Within each group, entries are sorted by address.
+ */
+static const ModulinoEntry MODULINO_MAP[] = {
+  // --- Configurable devices (pinstrap != 0, default addr = pinstrap / 2) ---
+  { 0x02, 0x04, "Latch Relay", FIRMWARE_GENERIC    },
+  { 0x14, 0x28, "Opto Relay",  FIRMWARE_GENERIC    },
+  { 0x1E, 0x3C, "Buzzer",      FIRMWARE_GENERIC    },
+  { 0x24, 0x48, "Motors",      FIRMWARE_MOTORS     },
+  { 0x2C, 0x58, "Joystick",    FIRMWARE_GENERIC    },
+  { 0x36, 0x6C, "Pixels",      FIRMWARE_GENERIC    },
+  { 0x38, 0x70, "Vibro",       FIRMWARE_GENERIC    },
+  { 0x39, 0x72, "LED Matrix",  FIRMWARE_LED_MATRIX },
+  { 0x3A, 0x74, "Knob",        FIRMWARE_GENERIC    },
+  { 0x3B, 0x76, "Knob",        FIRMWARE_GENERIC    },
+  { 0x3E, 0x7C, "Buttons",     FIRMWARE_GENERIC    },
+  // --- Fixed-address devices (pinstrap == 0) ---
+  { 0x29, 0x00, "Distance",    FIRMWARE_GENERIC    },
+  { 0x44, 0x00, "Thermo",      FIRMWARE_GENERIC    },
+  { 0x64, 0x00, "Bootloader",  FIRMWARE_GENERIC    },
+  { 0x6A, 0x00, "Movement",    FIRMWARE_GENERIC    },
+  { 0x6B, 0x00, "Movement",    FIRMWARE_GENERIC    },
+};
+
+/** @brief Number of entries in @ref MODULINO_MAP. */
+static constexpr size_t MODULINO_MAP_SIZE =
+    sizeof(MODULINO_MAP) / sizeof(MODULINO_MAP[0]);
+
+// --- Well-known address constants ---
+
+/** @brief I2C address used by the STM32 bootloader on all configurable Modulino modules. */
+static constexpr uint8_t MODULINO_BOOTLOADER_ADDR = 0x64;
+
+// --- Lookup helpers ---
+
+/**
+ * @brief Resolves a device name from a pinstrap byte.
+ * @param pinstrap The pinstrap value read from the device.
+ * @return The device name, or @c "UNKNOWN" if not in @ref MODULINO_MAP.
+ */
+inline String modulinoPinstrapToName(uint8_t pinstrap) {
+  for (size_t i = 0; i < MODULINO_MAP_SIZE; i++) {
+    if (MODULINO_MAP[i].pinstrap == pinstrap) return String(MODULINO_MAP[i].name);
+  }
+  return "UNKNOWN";
+}
+
+/**
+ * @brief Resolves a device name from a fixed I2C address.
+ * Only searches entries whose @c pinstrap is @c 0.
+ * @param address The fixed I2C address of the device.
+ * @return The device name, or @c "UNKNOWN" if not in @ref MODULINO_MAP.
+ */
+inline String modulinoFixedAddrToName(uint8_t address) {
+  for (size_t i = 0; i < MODULINO_MAP_SIZE; i++) {
+    if (MODULINO_MAP[i].pinstrap == 0 && MODULINO_MAP[i].addr == address) {
+      return String(MODULINO_MAP[i].name);
+    }
+  }
+  return "UNKNOWN";
+}
+
+/**
+ * @brief Returns @c true if @p addr belongs to a fixed-address device.
+ * A device is fixed-address when it has a @c pinstrap of @c 0 in @ref MODULINO_MAP.
+ * @param addr The I2C address to test.
+ */
+inline bool modulinoIsFixedAddrDevice(uint8_t addr) {
+  for (size_t i = 0; i < MODULINO_MAP_SIZE; i++) {
+    if (MODULINO_MAP[i].pinstrap == 0 && MODULINO_MAP[i].addr == addr) return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Returns the firmware image required for the device with the given pinstrap.
+ * @param pinstrap The device's pinstrap byte.
+ * @return The @ref ModulinoFirmware for that device, or @c FIRMWARE_GENERIC
+ *         if the pinstrap is not found in @ref MODULINO_MAP.
+ */
+inline ModulinoFirmware modulinoFirmwareForPinstrap(uint8_t pinstrap) {
+  for (size_t i = 0; i < MODULINO_MAP_SIZE; i++) {
+    if (MODULINO_MAP[i].pinstrap == pinstrap) return MODULINO_MAP[i].firmware;
+  }
+  return FIRMWARE_GENERIC;
+}

--- a/src/ModulinoFlasher.h
+++ b/src/ModulinoFlasher.h
@@ -1,0 +1,358 @@
+#pragma once
+
+// Copyright (c) 2025 Arduino SA
+// SPDX-License-Identifier: MPL-2.0
+
+#include "Modulino.h"
+#include "ModulinoAddresses.h"
+
+/**
+ * @file ModulinoFlasher.h
+ * @brief STM32 I2C bootloader protocol driver for writing Modulino firmware.
+ *
+ * Reference: STM32 I2C bootloader protocol
+ * https://www.st.com/resource/en/application_note/an4221-i2c-protocol-used-in-the-stm32-bootloader-stmicroelectronics.pdf
+ *
+ * Usage:
+ * @code
+ * Module modulino;
+ * ModulinoFlasher flasher(modulino);
+ *
+ * // After the target device is in bootloader mode and the reboot delay has elapsed:
+ * flasher.flash(firmware_bin, firmware_bin_len);
+ * @endcode
+ */
+
+// ─── SerialVerbose ────────────────────────────────────────────────────────────
+
+/**
+ * @brief Conditionally forwards print calls to Serial.
+ *
+ * Constructed with a @c verbose flag; all methods are no-ops when @c false.
+ */
+class SerialVerbose {
+public:
+  /**
+   * @brief Constructs a SerialVerbose instance.
+   * @param verbose If @c true, all print calls are forwarded to Serial.
+   */
+  SerialVerbose(bool verbose) : _verbose(verbose) {}
+
+  /** @brief Prints a String if verbose mode is enabled. */
+  void print(const String& s)           { if (_verbose) Serial.print(s); }
+  /** @brief Prints an integer if verbose mode is enabled. */
+  void print(int num, int base = DEC)   { if (_verbose) Serial.print(num, base); }
+  /** @brief Prints a String followed by newline if verbose mode is enabled. */
+  void println(const String& s)         { if (_verbose) Serial.println(s); }
+  /** @brief Prints an integer followed by newline if verbose mode is enabled. */
+  void println(int num, int base = DEC) { if (_verbose) Serial.println(num, base); }
+
+private:
+  bool _verbose;
+};
+
+// ─── ModulinoFlasher ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Flashes Modulino firmware over I2C using the STM32 bootloader protocol.
+ *
+ * The target device must already be in bootloader mode at @ref BOOTLOADER_ADDR
+ * before calling @ref flash(). Use @c ModulinoScanner::bootloaderReadyIn() to
+ * ensure the required reboot delay has elapsed after a reset.
+ */
+class ModulinoFlasher {
+public:
+  /** @brief I2C address of the STM32 bootloader. */
+  static constexpr uint8_t  BOOTLOADER_ADDR = MODULINO_BOOTLOADER_ADDR;
+  /** @brief Size of a single flash write page in bytes. */
+  static constexpr size_t   PAGE_SIZE       = 128;
+  /** @brief Base flash memory address on supported STM32 targets. */
+  static constexpr uint32_t FLASH_BASE_ADDR = 0x08000000;
+
+  /**
+   * @brief Progress callback invoked after groups of page writes.
+   *
+   * Signature: @c void callback(int currentPage, int totalPages)
+   */
+  using ProgressCallback = void(*)(int, int);
+
+  /**
+   * @brief Constructs a flasher bound to a Modulino bus instance.
+   * @param module The @c Module whose I2C bus is used for all bootloader communication.
+   */
+  ModulinoFlasher(Module& module) : _module(module) {}
+
+  /**
+   * @brief Sends a software-reset command to a Modulino, causing it to reboot
+   *        into the STM32 bootloader at @ref BOOTLOADER_ADDR.
+   *
+   * The Modulino firmware listens for the three-byte sequence @c {'D','I','E'}
+   * and performs a software reset upon receipt. After calling this function,
+   * wait at least @c ModulinoScanner::BOOTLOADER_REBOOT_MS milliseconds before
+   * issuing @ref flash().
+   *
+   * @param address The current I2C address of the target Modulino.
+   * @return @c true if the command was acknowledged, @c false if the device
+   *         did not respond (e.g. already in bootloader mode or disconnected).
+   */
+  bool enterBootloader(uint8_t address) {
+    uint8_t buf[128] = { 0 };
+    buf[0] = 'D'; buf[1] = 'I'; buf[2] = 'E';
+    
+    // Modulino firmwares check that the received I2C payload matches their exact
+    // struct size. We brute-force the length by padding with zeros until the device
+    // stops responding at its app address (indicating it has reset into the bootloader).
+    bool triggered = false;
+    for (uint8_t s = 3; s <= 128; s++) {
+      _module.getWire()->beginTransmission(address);
+      _module.getWire()->write(buf, s);
+      _module.getWire()->endTransmission();
+      
+      // Ping the device to see if it reset
+      _module.getWire()->beginTransmission(address);
+      if (_module.getWire()->endTransmission() != 0) {
+        triggered = true;
+        break;
+      }
+    }
+    return triggered;
+  }
+
+  /**
+   * @brief Erases flash memory and writes the given firmware image.
+   *
+   * Executes the full STM32 bootloader sequence: GET → GET_ID → MASS_ERASE →
+   * WRITE_MEMORY (paged) → GO. Progress is reported to @p onProgress every
+   * 4 pages and at completion.
+   *
+   * @param binary      Pointer to the firmware binary array.
+   * @param length      Total size of the firmware in bytes.
+   * @param verbose     If @c true, prints a detailed protocol trace to Serial.
+   * @param onProgress  Optional callback invoked with @c (currentPage, totalPages).
+   * @return @c true if the entire sequence succeeded, @c false on any failure.
+   */
+  bool flash(const uint8_t* binary, size_t length, bool verbose = false,
+             ProgressCallback onProgress = nullptr) {
+    SerialVerbose dbg(verbose);
+    uint8_t resp_buf[255];
+
+    dbg.println("GET_COMMAND");
+    if (executeGet(resp_buf, 20, dbg) < 0) {
+      Serial.println("Failed to get command. Ensure device is in bootloader mode.");
+      return false;
+    }
+    for (int i = 0; i < 20; i++) dbg.println(resp_buf[i], HEX);
+
+    dbg.println("GET_ID");
+    int id_len = executeGetId(resp_buf, 3, dbg);
+    for (int i = 0; i < id_len; i++) dbg.println(resp_buf[i], HEX);
+
+    dbg.println("MASS_ERASE");
+    Serial.println("Erasing flash...");
+    if (!executeMassErase(dbg)) {
+      Serial.println("Failed to completely erase flash.");
+      return false;
+    }
+
+    Serial.println("Flashing...");
+    int length_mod_page = ((length + PAGE_SIZE) / PAGE_SIZE) * PAGE_SIZE;
+    int total_pages     = (length_mod_page / PAGE_SIZE) + 1;
+    int current_page    = 0;
+
+    for (int offset = length_mod_page; offset >= 0; offset -= PAGE_SIZE) {
+      dbg.print("WRITE_PAGE OFFSET: ");
+      dbg.println(offset, HEX);
+
+      if (!executeWritePage(FLASH_BASE_ADDR + offset, &binary[offset], PAGE_SIZE, dbg)) {
+        Serial.println("Write page operation failed at intermediate step!");
+        return false;
+      }
+
+      delay(10);
+      current_page++;
+
+      if (current_page % 4 == 0 || current_page == total_pages) {
+        int progress = (current_page * 100) / total_pages;
+        Serial.print("Progress: ");
+        Serial.print(progress);
+        Serial.println("%");
+        if (onProgress) onProgress(current_page, total_pages);
+      }
+    }
+
+    Serial.println("Finishing up...");
+    dbg.println("GO");
+    if (!executeGo(FLASH_BASE_ADDR, dbg)) {
+      Serial.println("Failed to perform the final GO sequence jump.");
+      return false;
+    }
+
+    return true;
+  }
+
+private:
+  Module& _module;
+
+  // ─── Protocol constants ─────────────────────────────────────────────────────
+  static constexpr uint8_t CMD_GET          = 0x00; ///< GET command opcode.
+  static constexpr uint8_t CMD_GET_ID       = 0x02; ///< GET ID command opcode.
+  static constexpr uint8_t CMD_GO           = 0x21; ///< GO command opcode.
+  static constexpr uint8_t CMD_WRITE_MEMORY = 0x32; ///< WRITE MEMORY command opcode.
+  static constexpr uint8_t CMD_MASS_ERASE   = 0x44; ///< MASS ERASE command opcode.
+  static constexpr uint8_t ST_ACK           = 0x79; ///< ACK byte from the bootloader.
+  static constexpr uint8_t ST_BUSY          = 0x76; ///< BUSY byte from the bootloader.
+
+  // ─── Low-level helpers ──────────────────────────────────────────────────────
+
+  /**
+   * @brief Polls the bootloader until it sends an ACK (or a non-BUSY byte).
+   *
+   * @param dbg Debug logger.
+   * @return @c true if ACK was received, @c false if a NACK or unexpected byte arrived.
+   */
+  bool waitForAck(SerialVerbose& dbg) {
+    _module.getWire()->requestFrom(BOOTLOADER_ADDR, (uint8_t)1);
+    auto c = _module.getWire()->read();
+    while (c == ST_BUSY) {
+      delay(10);
+      _module.getWire()->requestFrom(BOOTLOADER_ADDR, (uint8_t)1);
+      c = _module.getWire()->read();
+    }
+    if (c != ST_ACK) {
+      dbg.print("error ack: ");
+      dbg.println(c, HEX);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * @brief Sends a command opcode followed by its bitwise inverse, then waits for ACK.
+   *
+   * @param opcode The command opcode byte.
+   * @param dbg    Debug logger.
+   * @return @c true if ACK was received.
+   */
+  bool sendOpcode(uint8_t opcode, SerialVerbose& dbg) {
+    uint8_t cmd[2] = { opcode, (uint8_t)(0xFF ^ opcode) };
+    _module.getWire()->beginTransmission(BOOTLOADER_ADDR);
+    _module.getWire()->write(cmd, 2);
+    _module.getWire()->endTransmission(true);
+    return waitForAck(dbg);
+  }
+
+  /**
+   * @brief Sends a data buffer with an XOR checksum, then waits for ACK.
+   *
+   * @param buffer            Data to send.
+   * @param length            Number of bytes in @p buffer.
+   * @param includeLengthByte If @c true, prepends @c (length - 1) before the data.
+   * @param dbg               Debug logger.
+   * @return @c true if ACK was received.
+   */
+  bool sendBufferWithChecksum(const uint8_t* buffer, size_t length,
+                              bool includeLengthByte, SerialVerbose& dbg) {
+    uint8_t checksum = 0;
+    _module.getWire()->beginTransmission(BOOTLOADER_ADDR);
+    if (includeLengthByte) {
+      uint8_t lenByte = length - 1;
+      _module.getWire()->write(lenByte);
+      checksum ^= lenByte;
+    }
+    for (size_t i = 0; i < length; i++) {
+      _module.getWire()->write(buffer[i]);
+      checksum ^= buffer[i];
+    }
+    _module.getWire()->write(checksum);
+    _module.getWire()->endTransmission(true);
+    return waitForAck(dbg);
+  }
+
+  // ─── Bootloader commands ────────────────────────────────────────────────────
+
+  /**
+   * @brief Issues the GET command to retrieve the bootloader version and supported commands.
+   *
+   * @param output  Buffer to store the response.
+   * @param max_len Maximum bytes to read into @p output.
+   * @param dbg     Debug logger.
+   * @return Number of bytes read, or @c -1 on failure.
+   */
+  int executeGet(uint8_t* output, int max_len, SerialVerbose& dbg) {
+    if (!sendOpcode(CMD_GET, dbg)) return -1;
+    _module.getWire()->requestFrom(BOOTLOADER_ADDR, (uint8_t)max_len);
+    int howmany = _module.getWire()->read();
+    for (int i = 0; i <= howmany; i++) output[i] = _module.getWire()->read();
+    if (!waitForAck(dbg)) return -1;
+    return howmany + 1;
+  }
+
+  /**
+   * @brief Issues the GET ID command to retrieve the MCU product ID.
+   *
+   * @param output  Buffer to store the ID bytes.
+   * @param max_len Maximum bytes to read.
+   * @param dbg     Debug logger.
+   * @return Number of ID bytes read, or @c -1 on failure.
+   */
+  int executeGetId(uint8_t* output, int max_len, SerialVerbose& dbg) {
+    if (!sendOpcode(CMD_GET_ID, dbg)) return -1;
+    _module.getWire()->requestFrom(BOOTLOADER_ADDR, (uint8_t)max_len);
+    int howmany = _module.getWire()->read();
+    for (int i = 0; i <= howmany; i++) output[i] = _module.getWire()->read();
+    if (!waitForAck(dbg)) return -1;
+    return howmany + 1;
+  }
+
+  /**
+   * @brief Issues the global MASS ERASE command to wipe all flash pages.
+   *
+   * @param dbg Debug logger.
+   * @return @c true if erase was acknowledged successfully.
+   */
+  bool executeMassErase(SerialVerbose& dbg) {
+    if (!sendOpcode(CMD_MASS_ERASE, dbg)) return false;
+    uint8_t erase_buf[2] = { 0xFF, 0xFF };
+    return sendBufferWithChecksum(erase_buf, 2, false, dbg);
+  }
+
+  /**
+   * @brief Issues the GO command to jump to the given flash address.
+   *
+   * @param address Target address (must be aligned to the MCU's vector table requirements).
+   * @param dbg     Debug logger.
+   * @return @c true if the bootloader acknowledged the jump.
+   */
+  bool executeGo(uint32_t address, SerialVerbose& dbg) {
+    if (!sendOpcode(CMD_GO, dbg)) return false;
+    uint8_t buf[4] = {
+      (uint8_t)((address >> 24) & 0xFF),
+      (uint8_t)((address >> 16) & 0xFF),
+      (uint8_t)((address >> 8)  & 0xFF),
+      (uint8_t)( address        & 0xFF)
+    };
+    return sendBufferWithChecksum(buf, 4, false, dbg);
+  }
+
+  /**
+   * @brief Issues the WRITE MEMORY command to program one page of flash.
+   *
+   * @param address Destination flash address for this page.
+   * @param buf_fw  Firmware data buffer (exactly @ref PAGE_SIZE bytes).
+   * @param len_fw  Number of bytes to write.
+   * @param dbg     Debug logger.
+   * @return @c true if the page was written and acknowledged.
+   */
+  bool executeWritePage(uint32_t address, const uint8_t* buf_fw, size_t len_fw,
+                        SerialVerbose& dbg) {
+    if (!sendOpcode(CMD_WRITE_MEMORY, dbg)) return false;
+    uint8_t addr_buf[4] = {
+      (uint8_t)((address >> 24) & 0xFF),
+      (uint8_t)((address >> 16) & 0xFF),
+      (uint8_t)((address >> 8)  & 0xFF),
+      (uint8_t)( address        & 0xFF)
+    };
+    if (!sendBufferWithChecksum(addr_buf, 4, false, dbg)) return false;
+    return sendBufferWithChecksum(buf_fw, len_fw, true, dbg);
+  }
+};

--- a/src/ModulinoScanner.h
+++ b/src/ModulinoScanner.h
@@ -1,0 +1,247 @@
+#pragma once
+
+// Copyright (c) 2025 Arduino SA
+// SPDX-License-Identifier: MPL-2.0
+
+#include "Modulino.h"
+#include "ModulinoAddresses.h"
+
+/**
+ * @file ModulinoScanner.h
+ * @brief I2C bus scanner for discovering connected Modulino devices.
+ *
+ * Address and name lookups are delegated to @ref ModulinoAddresses.h so that
+ * a single file is the authoritative source for all device metadata.
+ *
+ * Usage:
+ * @code
+ * Module modulino;
+ * ModulinoScanner scanner;
+ *
+ * Modulino.begin();
+ * scanner.discover(modulino);
+ * scanner.printDevices();
+ * @endcode
+ */
+
+/**
+ * @brief Holds the detected properties of a single Modulino device.
+ */
+struct DetectedModulino {
+  uint8_t addr;          ///< I2C address at which the device was found.
+  String modulinoType;   ///< Human-readable device type name.
+  bool isFixed;          ///< @c true if the device uses a fixed, non-configurable I2C address.
+  uint8_t pinstrapValue; ///< Raw pinstrap byte as read from the device, or @c 0 for fixed-address devices.
+};
+
+/**
+ * @brief Scans an I2C bus and maintains a list of discovered Modulino devices.
+ */
+class ModulinoScanner {
+public:
+  /** @brief Maximum number of devices tracked in a single scan. */
+  static constexpr int MAX_DEVICES = 16;
+
+  /**
+   * @brief Time in milliseconds for the STM32 bootloader to reboot after
+   *        being contacted during a scan or after receiving a reset command.
+   */
+  static constexpr unsigned long BOOTLOADER_REBOOT_MS = 6500;
+
+  DetectedModulino devices[MAX_DEVICES]; ///< Array of discovered devices.
+  int numDevices = 0;                    ///< Number of valid entries in @ref devices.
+
+  /**
+   * @brief Timestamp (@c millis()) of the most recent bootloader reset.
+   * Updated automatically by @ref discover() when a device at
+   * @ref MODULINO_BOOTLOADER_ADDR is found, and manually via
+   * @ref notifyBootloaderHasReset() after sending a software-reset command.
+   */
+  unsigned long lastBootloaderContactMs = 0;
+
+  /** @brief Default constructor. Call @ref begin() before @ref discover(). */
+  ModulinoScanner() : _wire(nullptr) {}
+
+  /**
+   * @brief Constructs a scanner bound to the given I2C bus.
+   * @param wire The I2C peripheral to use for all scan operations.
+   */
+  explicit ModulinoScanner(HardwareI2C& wire) : _wire(&wire) {}
+
+  /**
+   * @brief Binds the scanner to an I2C bus.
+   *
+   * Call this once in @c setup() after @c Modulino.begin(), or use the
+   * single-argument constructor instead.
+   *
+   * @param wire The I2C peripheral to use for all scan operations.
+   */
+  void begin(HardwareI2C& wire) { _wire = &wire; }
+
+  /**
+   * @brief Pings the bootloader address to check if a device is currently in bootloader mode.
+   *
+   * If the bootloader acknowledges the ping, @ref notifyBootloaderHasReset() is called 
+   * automatically because the probe causes the bootloader to reset.
+   *
+   * @return @c true if a device is in bootloader mode, @c false otherwise.
+   */
+  bool deviceInBootloaderMode() {
+    if (!_wire) return false;
+    _wire->beginTransmission(MODULINO_BOOTLOADER_ADDR);
+    if (_wire->endTransmission() == 0) {
+      notifyBootloaderHasReset();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @brief Scans the I2C bus and populates the internal device list.
+   *
+   * Uses the @c HardwareI2C bus provided at construction or via @ref begin().
+   * For each responding address, checks @ref modulinoIsFixedAddrDevice() to
+   * determine device type. Configurable devices are queried for their pinstrap
+   * byte. If @ref MODULINO_BOOTLOADER_ADDR responds, @ref notifyBootloaderHasReset()
+   * is called automatically because the probe causes the bootloader to reset.
+   */
+  void discover() {
+    if (!_wire) return;
+    numDevices = 0;
+
+    for (int addr = 1; addr < 128; addr++) {
+      _wire->beginTransmission((uint8_t)addr);
+      if (_wire->endTransmission() != 0) continue;
+      if (numDevices >= MAX_DEVICES) return;
+
+      if (modulinoIsFixedAddrDevice((uint8_t)addr)) {
+        if ((uint8_t)addr == MODULINO_BOOTLOADER_ADDR) notifyBootloaderHasReset();
+        addDevice((uint8_t)addr, modulinoFixedAddrToName((uint8_t)addr), true, 0);
+        continue;
+      }
+
+      uint8_t pinstrap = 0;
+      _wire->requestFrom((uint8_t)addr, (uint8_t)1);
+      if (_wire->available()) {
+        pinstrap = _wire->read();
+      } else {
+        // Ignore reserved I2C addresses (0x78-0x7F) if they return no data
+        if (addr >= 0x78) continue;
+      }
+
+      addDevice((uint8_t)addr, modulinoPinstrapToName(pinstrap), false, pinstrap);
+    }
+  }
+
+  /**
+   * @brief Prints the discovered device list to the Serial monitor.
+   *
+   * Outputs a formatted table with columns: ADDR, MODULINO, PINSTRAP, DEFAULT ADDR.
+   * When @p showIndex is @c true, each row is prefixed with a 1-based index number
+   * so the user can select a device by typing its number.
+   *
+   * @param showIndex If @c true, prepend a @c [n] index to every row.
+   */
+  void printDevices(bool showIndex = false) {
+    if (showIndex) Serial.print("     ");
+    Serial.print(padToWidth("ADDR", 8));
+    Serial.print(padToWidth("MODULINO", 16));
+    Serial.print(padToWidth("PINSTRAP", 16));
+    Serial.println("DEFAULT ADDR");
+    for (int i = 0; i < numDevices; i++) {
+      if (showIndex) {
+        char idx[6];
+        snprintf(idx, sizeof(idx), "[%2d] ", i + 1);
+        Serial.print(idx);
+      }
+      char buffer[16];
+      snprintf(buffer, 16, "0x%02X", devices[i].addr);
+      Serial.print(padToWidth(buffer, 8));
+      Serial.print(padToWidth(devices[i].modulinoType, 16));
+      if (devices[i].isFixed) {
+        Serial.print(padToWidth("-", 16));
+        Serial.println(padToWidth(buffer, 12));  // addr == default for fixed devices
+      } else {
+        snprintf(buffer, 16, "0x%02X", devices[i].pinstrapValue);
+        Serial.print(padToWidth(buffer, 16));
+        snprintf(buffer, 16, "0x%02X", devices[i].pinstrapValue / 2);
+        String defAddr = buffer;
+        if (devices[i].addr != devices[i].pinstrapValue / 2) defAddr += " *";
+        Serial.println(padToWidth(defAddr, 12));
+      }
+    }
+  }
+
+  /**
+   * @brief Finds a device by address in the last scan result.
+   *
+   * Returns a pointer into the internal @ref devices array, giving the caller
+   * direct access to type, pinstrap, and @ref DetectedModulino::isFixed without
+   * a separate @ref modulinoIsFixedAddrDevice() call.
+   *
+   * @param addr The I2C address to search for.
+   * @return Pointer to the matching @ref DetectedModulino, or @c nullptr if not found.
+   */
+  const DetectedModulino* getDevice(uint8_t addr) {
+    for (int i = 0; i < numDevices; i++) {
+      if (devices[i].addr == addr) return &devices[i];
+    }
+    return nullptr;
+  }
+
+  /**
+   * @brief Notifies the scanner that the STM32 bootloader has just been reset.
+   * Records the current time so @ref bootloaderReadyIn() can compute the
+   * remaining reboot delay. Call this after @ref ModulinoFlasher::enterBootloader()
+   * returns @c true, or whenever you know the bootloader has been triggered.
+   */
+  void notifyBootloaderHasReset() {
+    lastBootloaderContactMs = millis();
+  }
+
+  /**
+   * @brief Returns milliseconds remaining until the bootloader is ready for commands.
+   * After the STM32 bootloader is contacted (either by a scan or by a reset command),
+   * it takes @ref BOOTLOADER_REBOOT_MS to re-enumerate. This method returns how much
+   * of that time is still outstanding. Feed the result into @c delay() before calling
+   * @ref ModulinoFlasher::flash().
+   * @return Remaining wait in milliseconds, or @c 0 if the device should be ready.
+   */
+  unsigned long bootloaderReadyIn() const {
+    if (lastBootloaderContactMs == 0) return 0;
+    unsigned long elapsed = millis() - lastBootloaderContactMs;
+    if (elapsed >= BOOTLOADER_REBOOT_MS) return 0;
+    return BOOTLOADER_REBOOT_MS - elapsed;
+  }
+
+private:
+  HardwareI2C* _wire; ///< I2C bus used for scanning. Must be set via constructor or @ref begin().
+
+  /**
+   * @brief Appends a device entry to the internal list.
+   * Does nothing if the list is already at capacity (@ref MAX_DEVICES).
+   * @param address       The I2C address of the device.
+   * @param modulinoType  Human-readable device type name.
+   * @param isFixed       Whether the device has a fixed, non-configurable address.
+   * @param pinstrapValue Raw pinstrap byte, or @c 0 for fixed-address devices.
+   */
+  void addDevice(uint8_t address, String modulinoType, bool isFixed, uint8_t pinstrapValue) {
+    if (numDevices >= MAX_DEVICES) return;
+    devices[numDevices].addr = address;
+    devices[numDevices].modulinoType = modulinoType;
+    devices[numDevices].isFixed = isFixed;
+    devices[numDevices].pinstrapValue = pinstrapValue;
+    numDevices++;
+  }
+
+  /**
+   * @brief Pads @p str with trailing spaces to a minimum display width.
+   * @param str   The string to pad.
+   * @param width Desired minimum character width.
+   * @return The padded @c String.
+   */
+  String padToWidth(String str, int width) {
+    for (int i = str.length(); i < width; i++) str += ' ';
+    return str;
+  }
+};


### PR DESCRIPTION
This PR extracts the logic for scanning Modulinos into its separate class to be used by the firmware updater and the address changer sketch. Also the list of Modulinos with their default addresses etc. is now maintained in one single file. Adding new Modulinos will be easier that way.

The firmware updater sketch now correctly handles devices that are stuck in bootloader mode. Also, it asks the user if they want to start flashing which avoids an issue that some people had who unplugged their board halfway when flashing which bricked the modules. It also features a nicer interactive mode to select the Modulino to be flashed.